### PR TITLE
fix jwt caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "pg_session_jwt"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64ct",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["pgrx-tests"]
 
 [package]
 name = "pg_session_jwt"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/sql/pg_session_jwt--0.1.1--0.1.2.sql
+++ b/sql/pg_session_jwt--0.1.1--0.1.2.sql
@@ -1,0 +1,1 @@
+-- no migration necessary. just a bug fix


### PR DESCRIPTION
An attempt at fixing #17.

Don't rely on `set_jwt_cache()`, instead always pull the JWT from the GUC and validate it against the cache.