### PR TITLE
add 60s expiration leeway to account for latency and clock-skew

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "pg_session_jwt"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64ct",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["pgrx-tests"]
 
 [package]
 name = "pg_session_jwt"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [lib]

--- a/sql/pg_session_jwt--0.3.0--0.3.1.sql
+++ b/sql/pg_session_jwt--0.3.0--0.3.1.sql
@@ -1,0 +1,2 @@
+-- no migration necessary.
+-- adds 60s leeway to expiration validation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@ pub mod auth {
 
     type Object = serde_json::Map<String, serde_json::Value>;
 
+    /// local-proxy/auth-broker use a leeway of 30s. We add a little
+    /// bit more leeway here to account for any delays before getting to the extension.
     const CLOCK_SKEW_LEEWAY: Duration = Duration::from_secs(60);
 
     /// A octet key pair CFRG-curve key, as defined in [RFC 8037]


### PR DESCRIPTION
auth-broker and local-proxy use a 30s leeway, using the same calculation. 60 leeway here allows for just a bit more wiggle room. Generally any expiration errors will be caught by auth-broker, so we allow pg-session-jwt to be just a tiny bit more permissive.

Related to INC-509