### PR TITLE
feat: GUC for audit logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ Returns the user ID associated with the current session. The behavior depends on
 
 This dual behavior allows for flexible authentication scenarios while maintaining security when JWK is available, and compatibility with PostgREST JWT claims when operating without JWK.
 
+Audit logs
+----------
+In order to enable audit logs set `pg_session_jwt.audit_log` as `on`.
+
+
 License
 -------
 This project is licensed under the Apache License 2.0. See the LICENSE file for details.

--- a/sql/pg_session_jwt--0.3.0--0.3.1.sql
+++ b/sql/pg_session_jwt--0.3.0--0.3.1.sql
@@ -1,2 +1,3 @@
 -- no migration necessary.
 -- adds 60s leeway to expiration validation
+-- audit logs are enabled for pg_session_jwt.audit_log=on

--- a/src/gucs.rs
+++ b/src/gucs.rs
@@ -36,7 +36,7 @@ pub fn init() {
     GucRegistry::define_string_guc(
         NEON_AUTH_ENABLE_AUDIT_LOG_PARAM,
         "Enable audit logs",
-        "Setting as 'true' enables audit logs that are produced each time JWT is validated and/or read",
+        "Setting as 'on' enables audit logs that are produced each time JWT is validated and/or read",
         &NEON_AUTH_ENABLE_AUDIT_LOG,
         GucContext::Suset,
         GucFlags::NOT_WHILE_SEC_REST,

--- a/src/gucs.rs
+++ b/src/gucs.rs
@@ -7,6 +7,12 @@ pub static NEON_AUTH_JWK: GucSetting<Option<&'static CStr>> =
 pub static NEON_AUTH_JWT_RUNTIME_PARAM: &str = "pg_session_jwt.jwt";
 pub static NEON_AUTH_JWT: GucSetting<Option<&'static CStr>> =
     GucSetting::<Option<&'static CStr>>::new(None);
+pub static NEON_AUTH_ENABLE_AUDIT_LOG_PARAM: &str = "pg_session_jwt.audit_log";
+pub static NEON_AUTH_ENABLE_AUDIT_LOG: GucSetting<Option<&'static CStr>> =
+    GucSetting::<Option<&'static CStr>>::new(None);
+pub static POSTGREST_JWT_RUNTIME_PARAM: &str = "request.jwt.claims";
+pub static POSTGREST_JWT: GucSetting<Option<&'static CStr>> =
+    GucSetting::<Option<&'static CStr>>::new(None);
 
 pub fn init() {
     GucRegistry::define_string_guc(
@@ -23,6 +29,24 @@ pub fn init() {
         "JSON Web Token (JWT) used for query authorization",
         "Represents authenticated user session related claims like user ID",
         &NEON_AUTH_JWT,
+        GucContext::Userset,
+        GucFlags::NOT_WHILE_SEC_REST,
+    );
+
+    GucRegistry::define_string_guc(
+        NEON_AUTH_ENABLE_AUDIT_LOG_PARAM,
+        "Enable audit logs",
+        "Setting as 'true' enables audit logs that are produced each time JWT is validated and/or read",
+        &NEON_AUTH_ENABLE_AUDIT_LOG,
+        GucContext::Suset,
+        GucFlags::NOT_WHILE_SEC_REST,
+    );
+
+    GucRegistry::define_string_guc(
+        POSTGREST_JWT_RUNTIME_PARAM,
+        "JSON Web Token (JWT) used for query authorization",
+        "PostgREST compatible GUC. Represents authenticated user session related claims like user ID",
+        &POSTGREST_JWT,
         GucContext::Userset,
         GucFlags::NOT_WHILE_SEC_REST,
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,8 +289,8 @@ pub mod auth {
             .get()
             .unwrap_or(CString::default().as_c_str())
             .to_str()
-            .unwrap_or("")
-            == "true"
+            .unwrap_or("off")
+            == "on"
     }
 
     fn log_audit_validated_jwt(payload: &Object) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub mod auth {
 
     /// local-proxy/auth-broker use a leeway of 30s. We add a little
     /// bit more leeway here to account for any delays before getting to the extension.
-    const CLOCK_SKEW_LEEWAY: Duration = Duration::from_secs(60);
+    pub const CLOCK_SKEW_LEEWAY: Duration = Duration::from_secs(60);
 
     /// A octet key pair CFRG-curve key, as defined in [RFC 8037]
     ///
@@ -285,7 +285,7 @@ pub mod auth {
     }
 
     fn can_log_audit() -> bool {
-        let log_var = NEON_AUTH_ENABLE_AUDIT_LOG.get().map(|x| x.as_bytes());
+        let log_var = NEON_AUTH_ENABLE_AUDIT_LOG.get().map(|x| x.to_bytes());
         matches!(log_var, Some(b"on"))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,12 +285,8 @@ pub mod auth {
     }
 
     fn can_log_audit() -> bool {
-        NEON_AUTH_ENABLE_AUDIT_LOG
-            .get()
-            .unwrap_or(CString::default().as_c_str())
-            .to_str()
-            .unwrap_or("off")
-            == "on"
+        let log_var = NEON_AUTH_ENABLE_AUDIT_LOG.get().map(|x| x.as_bytes());
+        matches!(log_var, Some(b"on"))
     }
 
     fn log_audit_validated_jwt(payload: &Object) {

--- a/tests/pg_session_jwt.rs
+++ b/tests/pg_session_jwt.rs
@@ -8,6 +8,8 @@ use libtest_mimic::{run, Trial};
 use rand::rngs::OsRng;
 use serde_json::json;
 
+use pg_session_jwt::auth::CLOCK_SKEW_LEEWAY;
+
 fn main() -> ExitCode {
     let mut args = libtest_mimic::Arguments::from_args();
     // fixes concurrent update failures
@@ -102,8 +104,9 @@ fn invalid_nbf(sk: &SigningKey, tx: &mut postgres::Client) -> Result<(), postgre
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
+    let nbf_leeway = CLOCK_SKEW_LEEWAY.as_secs() + 10;
 
-    let jwt = sign_jwt(sk, r#"{"kid":1}"#, json!({"jti": 1, "nbf": now + 70}));
+    let jwt = sign_jwt(sk, r#"{"kid":1}"#, json!({"jti": 1, "nbf": now + nbf_leeway}));
 
     tx.execute("select auth.init()", &[])?;
     tx.execute("select auth.jwt_session_init($1)", &[&jwt])?;
@@ -116,11 +119,12 @@ fn invalid_exp(sk: &SigningKey, tx: &mut postgres::Client) -> Result<(), postgre
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
+    let exp_leeway = CLOCK_SKEW_LEEWAY.as_secs() + 5;
 
     let jwt = sign_jwt(
         sk,
         r#"{"kid":1}"#,
-        json!({"jti": 1,  "nbf": now - 70, "exp": now - 65}),
+        json!({"jti": 1,  "exp": now - exp_leeway}),
     );
 
     tx.execute("select auth.init()", &[])?;
@@ -134,12 +138,14 @@ fn valid_time(sk: &SigningKey, tx: &mut postgres::Client) -> Result<(), postgres
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
+    let nbf_leeway = CLOCK_SKEW_LEEWAY.as_secs() - 10;
+    let exp_leeway = CLOCK_SKEW_LEEWAY.as_secs() + 10;
 
     let header = r#"{"kid":1}"#;
     let jwt1 = sign_jwt(
         sk,
         header,
-        json!({"jti": 1, "nbf": now - 10, "exp": now + 10}),
+        json!({"jti": 1, "nbf": now - nbf_leeway, "exp": now + exp_leeway}),
     );
     let jwt2 = sign_jwt(sk, header, json!({"jti": 2, "nbf": now - 10}));
     let jwt3 = sign_jwt(sk, header, json!({"jti": 3, "exp": now + 10}));


### PR DESCRIPTION
related to https://github.com/neondatabase/cloud/issues/28480

cc @MihaiBojin @luist18 @lneves12 

tested manually with:
```console
tail -F ~/.pgrx/16.log
```
```console
cargo pgrx run pg16
```
```sql
drop extension pg_session_jwt cascade;
create extension pg_session_jwt;

SET request.jwt.claims = '{"sub":"Bar"}';
select auth.user_id();
SET pg_session_jwt.audit_log = 'on';
select auth.user_id();
```