### PR TITLE
feat: add Neon Auth organization helpers (auth.organization)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["pgrx-tests"]
 
 [package]
 name = "pg_session_jwt"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The `auth` schema mixes **portable** helpers (work with most JWT issuers) and **
 
 | Function | Portable? | Notes |
 |----------|-----------|-------|
-| `auth.user_id()`, `auth.uid()` | Yes | Reads standard `sub` claim |
+| `auth.user_id()`, `auth.uid()` | Yes | Reads standard `sub` claim (`user_id` as text, `uid` as uuid when `sub` parses) |
 | `auth.session()`, `auth.jwt()` | Yes | Returns the full JWT payload / claims JSON |
-| `auth.organization()`, `auth.organization_id()` | **Neon Auth only** | Reads the `"o"` claim from the [Neon Auth organization plugin](https://neon.tech/docs/neon-auth/overview) |
+| `auth.organization()`, `auth.organization_id()` | **Neon Auth only** | Reads the `"o"` claim (`organization_id` returns uuid for Neon Auth `organization_id` columns) |
 
 **Other auth providers** (Auth0, Clerk, Supabase, Firebase, Cognito, etc.) do not share a standard organization claim name or shape in access tokens. Many do not include an active organization in the JWT at all. For those providers:
 
@@ -139,11 +139,11 @@ Behavior matches `auth.jwt()` / `auth.session()` for JWK-validated JWTs vs Postg
 - Returns the full `"o"` object as JSONB when present and is a JSON object.
 - Returns SQL `NULL` when the JWT is missing, invalid, has no `"o"` claim, or `"o"` is not a JSON object.
 
-### 8\. auth.organization\_id() → text
+### 8\. auth.organization\_id() → uuid
 
 > **Neon Auth only.**
 
-Returns `auth.organization() ->> 'id'`. Returns SQL `NULL` when there is no active organization or when `"id"` is missing or not a string.
+Returns `auth.organization() ->> 'id'` parsed as `uuid`, for direct comparison with Neon Auth `organization_id` columns (same invalid-UUID → `NULL` behavior as `auth.uid()`). Returns SQL `NULL` when there is no active organization, when `"id"` is missing, or when `"id"` is not a valid UUID string.
 
 #### Organization-scoped RLS example
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,28 @@ Features
 
 * **Retrieve the user ID** or other session-related information directly from the database.
 
+* **Organization helpers for Neon Auth** (`auth.organization()`, `auth.organization_id()`) when using the Neon Auth organization plugin.
+
 * Simple JSONB-based storage and retrieval of session information.
+
+Auth provider compatibility
+---------------------------
+
+The `auth` schema mixes **portable** helpers (work with most JWT issuers) and **Neon Auth–specific** helpers.
+
+| Function | Portable? | Notes |
+|----------|-----------|-------|
+| `auth.user_id()`, `auth.uid()` | Yes | Reads standard `sub` claim |
+| `auth.session()`, `auth.jwt()` | Yes | Returns the full JWT payload / claims JSON |
+| `auth.organization()`, `auth.organization_id()` | **Neon Auth only** | Reads the `"o"` claim from the [Neon Auth organization plugin](https://neon.tech/docs/neon-auth/overview) |
+
+**Other auth providers** (Auth0, Clerk, Supabase, Firebase, Cognito, etc.) do not share a standard organization claim name or shape in access tokens. Many do not include an active organization in the JWT at all. For those providers:
+
+- Use `auth.jwt()` and extract whatever claim your issuer documents (for example a custom namespaced claim).
+- Do **not** rely on `auth.organization()` unless your tokens intentionally include Neon Auth’s `"o"` object: `{"id": "<uuid>", "slug": "<string>", "role": "<member-role>"}`.
+- When `"o"` is absent or not a JSON object, `auth.organization()` and `auth.organization_id()` return SQL `NULL`. RLS policies that compare against them therefore fail closed (no rows match), which is usually desirable.
+
+There is no plan to normalize organization data across providers inside this extension; `auth.jwt()` remains the generic escape hatch.
 
 Usage
 -----
@@ -102,6 +123,46 @@ This dual behavior allows for flexible authentication scenarios while maintainin
 ### 6\. auth.uid() → uuid
 Similar to `auth.user_id()` but returns UUID. Expects `"sub"` to be UUID,
 otherwise returns NULL.
+
+### 7\. auth.organization() → jsonb
+
+> **Neon Auth only.** See [Auth provider compatibility](#auth-provider-compatibility) for portable vs Neon-specific functions.
+
+Returns the active organization from the JWT `"o"` claim (Neon Auth organization plugin). The claim shape is:
+
+```json
+{"id": "<uuid>", "slug": "<string>", "role": "<member-role>"}
+```
+
+Behavior matches `auth.jwt()` / `auth.session()` for JWK-validated JWTs vs PostgREST `request.jwt.claims`:
+
+- Returns the full `"o"` object as JSONB when present and is a JSON object.
+- Returns SQL `NULL` when the JWT is missing, invalid, has no `"o"` claim, or `"o"` is not a JSON object.
+
+### 8\. auth.organization\_id() → text
+
+> **Neon Auth only.**
+
+Returns `auth.organization() ->> 'id'`. Returns SQL `NULL` when there is no active organization or when `"id"` is missing or not a string.
+
+#### Organization-scoped RLS example
+
+```sql
+-- Team rows
+CREATE POLICY team_select ON team
+  FOR SELECT
+  USING (organization_id = auth.organization_id());
+
+-- Role-gated (optional)
+CREATE POLICY team_admin_update ON team
+  FOR UPDATE
+  USING (
+    organization_id = auth.organization_id()
+    AND (auth.organization() ->> 'role') IN ('admin', 'owner')
+  );
+```
+
+A copy-paste snippet for Neon docs lives in [`docs/organization-rls-snippet.md`](docs/organization-rls-snippet.md).
 
 Audit logs
 ----------

--- a/docs/organization-rls-snippet.md
+++ b/docs/organization-rls-snippet.md
@@ -15,7 +15,7 @@ When `"o"` is missing or malformed, both functions return SQL `NULL` (RLS polici
 ## Functions
 
 - `auth.organization()` — full `"o"` object as `jsonb`, or SQL `NULL` if there is no active organization
-- `auth.organization_id()` — `"o"."id"` as `text`, or SQL `NULL` if there is no active organization
+- `auth.organization_id()` — `"o"."id"` as `uuid`, or SQL `NULL` if there is no active organization or id is not a valid UUID
 
 ## Row Level Security example
 

--- a/docs/organization-rls-snippet.md
+++ b/docs/organization-rls-snippet.md
@@ -1,0 +1,44 @@
+# Neon docs snippet: organization-scoped RLS
+
+Use with [Neon RLS](https://neon.tech/docs/guides/neon-rls) and the **[Neon Auth organization plugin](https://neon.tech/docs/neon-auth/overview)** only.
+
+`auth.organization()` and `auth.organization_id()` read Neon Auth’s `"o"` claim. They are **not** portable across arbitrary auth providers (Auth0, Clerk, Supabase, etc.), which use different claim names and shapes or omit organization from the JWT entirely. For other issuers, use `auth.jwt()` and the claim path your provider documents.
+
+The active organization claim shape:
+
+```json
+{"id": "<uuid>", "slug": "<string>", "role": "<member-role>"}
+```
+
+When `"o"` is missing or malformed, both functions return SQL `NULL` (RLS policies using them fail closed).
+
+## Functions
+
+- `auth.organization()` — full `"o"` object as `jsonb`, or SQL `NULL` if there is no active organization
+- `auth.organization_id()` — `"o"."id"` as `text`, or SQL `NULL` if there is no active organization
+
+## Row Level Security example
+
+```sql
+-- Team rows: scope to the active organization
+CREATE POLICY team_select ON team
+  FOR SELECT
+  USING (organization_id = auth.organization_id());
+
+-- Role-gated writes (optional)
+CREATE POLICY team_admin_update ON team
+  FOR UPDATE
+  USING (
+    organization_id = auth.organization_id()
+    AND (auth.organization() ->> 'role') IN ('admin', 'owner')
+  );
+```
+
+## Other auth providers
+
+Example using the generic payload instead of Neon-specific helpers:
+
+```sql
+-- Replace 'your_org_claim' with the claim name your issuer documents
+USING (organization_id = auth.jwt() -> 'your_org_claim' ->> 'id')
+```

--- a/sql/pg_session_jwt--0.4.0--0.5.0.sql
+++ b/sql/pg_session_jwt--0.4.0--0.5.0.sql
@@ -4,7 +4,7 @@ STABLE PARALLEL SAFE
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'organization_wrapper';
 
-CREATE OR REPLACE FUNCTION auth."organization_id"() RETURNS text
+CREATE OR REPLACE FUNCTION auth."organization_id"() RETURNS uuid
 STABLE PARALLEL SAFE
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'organization_id_wrapper';

--- a/sql/pg_session_jwt--0.4.0--0.5.0.sql
+++ b/sql/pg_session_jwt--0.4.0--0.5.0.sql
@@ -1,0 +1,10 @@
+-- adds auth.organization() and auth.organization_id() for Neon Auth organization plugin
+CREATE OR REPLACE FUNCTION auth."organization"() RETURNS jsonb
+STABLE PARALLEL SAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'organization_wrapper';
+
+CREATE OR REPLACE FUNCTION auth."organization_id"() RETURNS text
+STABLE PARALLEL SAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'organization_id_wrapper';

--- a/sql/pg_session_jwt--0.5.0--0.4.0.sql
+++ b/sql/pg_session_jwt--0.5.0--0.4.0.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION IF EXISTS auth.organization_id();
+DROP FUNCTION IF EXISTS auth.organization();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,6 +372,45 @@ pub mod auth {
             .map(|uuid| PgUuid::from_bytes(*uuid.as_bytes()))
     }
 
+    fn jwt_claims() -> Option<serde_json::Value> {
+        if NEON_AUTH_JWK.get().is_none() {
+            return get_claims_from_guc();
+        }
+        validate_jwt().map(serde_json::Value::Object)
+    }
+
+    fn organization_claim() -> Option<serde_json::Value> {
+        let claims = jwt_claims()?;
+        if claims.is_null() {
+            return None;
+        }
+        let o = claims.get("o")?;
+        if o.is_null() {
+            return None;
+        }
+        Some(o.clone())
+    }
+
+    /// Active organization from the JWT `"o"` claim (Neon Auth organization plugin).
+    #[pg_extern(parallel_safe, stable)]
+    pub fn organization() -> Option<JsonB> {
+        let o = organization_claim()?;
+        if !o.is_object() {
+            return None;
+        }
+        Some(JsonB(o))
+    }
+
+    /// Organization id from the active organization claim (`"o"."id"`).
+    #[pg_extern(parallel_safe, stable)]
+    pub fn organization_id() -> Option<String> {
+        organization().and_then(|org| {
+            org.0
+                .get("id")
+                .and_then(|id| id.as_str().map(|s| s.to_owned()))
+        })
+    }
+
     fn json_base64_decode<D: DeserializeOwned>(s: &str) -> D {
         let r = Decoder::<Base64UrlUnpadded>::new(s.as_bytes()).unwrap_or_else(|e| {
             error_code!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,12 +402,17 @@ pub mod auth {
     }
 
     /// Organization id from the active organization claim (`"o"."id"`).
+    ///
+    /// Returns `uuid` for comparison with Neon Auth `organization_id` columns.
+    /// Returns SQL `NULL` when missing or not a valid UUID string (same as `auth.uid()`).
     #[pg_extern(parallel_safe, stable)]
-    pub fn organization_id() -> Option<String> {
+    pub fn organization_id() -> Option<PgUuid> {
         organization().and_then(|org| {
             org.0
                 .get("id")
-                .and_then(|id| id.as_str().map(|s| s.to_owned()))
+                .and_then(|id| id.as_str())
+                .and_then(|s| Uuid::parse_str(s).ok())
+                .map(|uuid| PgUuid::from_bytes(*uuid.as_bytes()))
         })
     }
 

--- a/tests/pg_session_jwt.rs
+++ b/tests/pg_session_jwt.rs
@@ -390,8 +390,15 @@ fn test_organization_with_jwk(
         org_matches,
         "auth.organization() should return the full o claim"
     );
-    let org_id: Option<String> = tx.query_one("SELECT auth.organization_id()", &[])?.get(0);
+    let org_id: Option<String> = tx.query_one("SELECT auth.organization_id()::text", &[])?.get(0);
     assert_eq!(org_id, Some(ORG_ID.to_string()));
+    let org_id_is_uuid: Option<bool> = tx
+        .query_one(
+            format!("SELECT auth.organization_id() = '{ORG_ID}'::uuid").as_str(),
+            &[],
+        )?
+        .get(0);
+    assert_eq!(org_id_is_uuid, Some(true));
 
     // Malformed "o" (string)
     let jwt_bad_org = sign_jwt(sk, header, json!({"sub": "user", "jti": 3, "o": "not-an-object"}));
@@ -413,8 +420,18 @@ fn test_organization_with_jwk(
         Some(true),
         "organization() should return object even without id"
     );
-    let org_id: Option<String> = tx.query_one("SELECT auth.organization_id()", &[])?.get(0);
+    let org_id: Option<String> = tx.query_one("SELECT auth.organization_id()::text", &[])?.get(0);
     assert_eq!(org_id, None);
+
+    // Invalid UUID in "id"
+    let jwt_bad_id = sign_jwt(
+        sk,
+        header,
+        json!({"sub": "user", "jti": 5, "o": {"id": "not-a-uuid", "slug": "acme", "role": "member"}}),
+    );
+    tx.execute("select auth.jwt_session_init($1)", &[&jwt_bad_id])?;
+    let org_id: Option<String> = tx.query_one("SELECT auth.organization_id()::text", &[])?.get(0);
+    assert_eq!(org_id, None, "invalid organization id should return NULL");
 
     Ok(())
 }
@@ -436,7 +453,7 @@ fn test_organization_from_claims(tx: &mut postgres::Client) -> Result<(), postgr
         .as_str(),
         &[],
     )?;
-    let org_id: Option<String> = tx.query_one("SELECT auth.organization_id()", &[])?.get(0);
+    let org_id: Option<String> = tx.query_one("SELECT auth.organization_id()::text", &[])?.get(0);
     assert_eq!(org_id, Some(ORG_ID.to_string()));
 
     tx.execute(
@@ -462,7 +479,7 @@ fn assert_organization_null(tx: &mut postgres::Client) -> Result<(), postgres::E
         .get(0);
     assert_eq!(org, None, "auth.organization() should be SQL NULL");
 
-    let org_id: Option<String> = tx.query_one("SELECT auth.organization_id()", &[])?.get(0);
+    let org_id: Option<String> = tx.query_one("SELECT auth.organization_id()::text", &[])?.get(0);
     assert_eq!(org_id, None, "auth.organization_id() should be SQL NULL");
 
     let org_is_null: bool = tx

--- a/tests/pg_session_jwt.rs
+++ b/tests/pg_session_jwt.rs
@@ -56,6 +56,19 @@ fn main() -> ExitCode {
         "test_session_fallback_when_not_set",
         test_session_fallback_when_not_set,
     ));
+    tests.push(test_fn(
+        "test_organization_with_jwk",
+        None,
+        test_organization_with_jwk,
+    ));
+    tests.push(test_without_jwk(
+        "test_organization_from_claims",
+        test_organization_from_claims,
+    ));
+    tests.push(test_without_jwk(
+        "test_organization_when_claims_not_set",
+        test_organization_when_claims_not_set,
+    ));
 
     run(&args, tests).exit_code()
 }
@@ -327,6 +340,139 @@ fn test_session_fallback_when_set(tx: &mut postgres::Client) -> Result<(), postg
     );
     let role_alias: Option<String> = tx.query_one("SELECT (auth.jwt()->>'role')", &[])?.get(0);
     assert_eq!(role_alias, role);
+
+    Ok(())
+}
+
+const ORG_ID: &str = "11111111-1111-1111-1111-111111111111";
+
+fn test_organization_with_jwk(
+    sk: &SigningKey,
+    tx: &mut postgres::Client,
+) -> Result<(), postgres::Error> {
+    let header = r#"{"kid":1}"#;
+
+    tx.execute("select auth.init()", &[])?;
+
+    // No JWT set
+    assert_organization_null(tx)?;
+
+    // Valid JWT without "o"
+    let jwt_no_org = sign_jwt(sk, header, r#"{"sub":"user","jti":1}"#);
+    tx.execute("select auth.jwt_session_init($1)", &[&jwt_no_org])?;
+    assert_organization_null(tx)?;
+
+    // Valid "o" claim
+    let jwt_with_org = sign_jwt(
+        sk,
+        header,
+        json!({
+            "sub": "user",
+            "jti": 2,
+            "o": {
+                "id": ORG_ID,
+                "slug": "acme",
+                "role": "admin"
+            }
+        }),
+    );
+    tx.execute("select auth.jwt_session_init($1)", &[&jwt_with_org])?;
+    let org_matches: bool = tx
+        .query_one(
+            format!(
+                "SELECT auth.organization() = '{{\"id\":\"{ORG_ID}\",\"slug\":\"acme\",\"role\":\"admin\"}}'::jsonb"
+            )
+            .as_str(),
+            &[],
+        )?
+        .get(0);
+    assert!(
+        org_matches,
+        "auth.organization() should return the full o claim"
+    );
+    let org_id: Option<String> = tx.query_one("SELECT auth.organization_id()", &[])?.get(0);
+    assert_eq!(org_id, Some(ORG_ID.to_string()));
+
+    // Malformed "o" (string)
+    let jwt_bad_org = sign_jwt(sk, header, json!({"sub": "user", "jti": 3, "o": "not-an-object"}));
+    tx.execute("select auth.jwt_session_init($1)", &[&jwt_bad_org])?;
+    assert_organization_null(tx)?;
+
+    // Malformed "o" (object missing id)
+    let jwt_missing_id = sign_jwt(
+        sk,
+        header,
+        json!({"sub": "user", "jti": 4, "o": {"slug": "acme", "role": "member"}}),
+    );
+    tx.execute("select auth.jwt_session_init($1)", &[&jwt_missing_id])?;
+    let org: Option<String> = tx
+        .query_one("SELECT auth.organization() IS NOT NULL", &[])?
+        .get(0);
+    assert_eq!(
+        org,
+        Some(true),
+        "organization() should return object even without id"
+    );
+    let org_id: Option<String> = tx.query_one("SELECT auth.organization_id()", &[])?.get(0);
+    assert_eq!(org_id, None);
+
+    Ok(())
+}
+
+fn test_organization_from_claims(tx: &mut postgres::Client) -> Result<(), postgres::Error> {
+    tx.execute("RESET request.jwt.claims", &[])?;
+    assert_organization_null(tx)?;
+
+    tx.execute(
+        r#"SET request.jwt.claims = '{"sub":"user"}'"#,
+        &[],
+    )?;
+    assert_organization_null(tx)?;
+
+    tx.execute(
+        format!(
+            r#"SET request.jwt.claims = '{{"sub":"user","o":{{"id":"{ORG_ID}","slug":"acme","role":"owner"}}}}'"#
+        )
+        .as_str(),
+        &[],
+    )?;
+    let org_id: Option<String> = tx.query_one("SELECT auth.organization_id()", &[])?.get(0);
+    assert_eq!(org_id, Some(ORG_ID.to_string()));
+
+    tx.execute(
+        r#"SET request.jwt.claims = '{"sub":"user","o":"bad"}'"#,
+        &[],
+    )?;
+    assert_organization_null(tx)?;
+
+    Ok(())
+}
+
+fn test_organization_when_claims_not_set(
+    tx: &mut postgres::Client,
+) -> Result<(), postgres::Error> {
+    tx.execute("RESET request.jwt.claims", &[])?;
+    assert_organization_null(tx)?;
+    Ok(())
+}
+
+fn assert_organization_null(tx: &mut postgres::Client) -> Result<(), postgres::Error> {
+    let org: Option<String> = tx
+        .query_one("SELECT auth.organization()::text", &[])?
+        .get(0);
+    assert_eq!(org, None, "auth.organization() should be SQL NULL");
+
+    let org_id: Option<String> = tx.query_one("SELECT auth.organization_id()", &[])?.get(0);
+    assert_eq!(org_id, None, "auth.organization_id() should be SQL NULL");
+
+    let org_is_null: bool = tx
+        .query_one("SELECT auth.organization() IS NULL", &[])?
+        .get(0);
+    assert!(org_is_null);
+    let org_id_is_null: bool = tx
+        .query_one("SELECT auth.organization_id() IS NULL", &[])?
+        .get(0);
+    assert!(org_id_is_null);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Add `auth.organization()` and `auth.organization_id()` for the Neon Auth organization plugin `"o"` claim (`{id, slug, role}`), following the same JWK vs `request.jwt.claims` code paths as `auth.jwt()` / `auth.user_id()`.
- Bump extension version to **0.5.0** with upgrade/downgrade SQL migrations.
- Document **portable vs Neon-specific** `auth` APIs: `user_id` / `jwt` work with most providers; organization helpers are Neon Auth only; other issuers should use `auth.jwt()` with their own claim paths.
- Add tests (null JWT, missing `o`, valid `o`, malformed `o`) and a Neon docs RLS snippet in `docs/organization-rls-snippet.md`.

## Auth provider compatibility

| Function | Portable? |
|----------|-----------|
| `auth.user_id()`, `auth.uid()`, `auth.session()`, `auth.jwt()` | Yes — standard JWT / claims access |
| `auth.organization()`, `auth.organization_id()` | **Neon Auth only** — reads `"o"` claim |

Other providers (Auth0, Clerk, Supabase, etc.) do not use this claim shape. Those functions return SQL `NULL` when `"o"` is absent, so RLS policies fail closed. Generic org access: `auth.jwt() -> '<your-claim>'`.

## Test plan

- [ ] `cargo test`
- [ ] Extension upgrade/downgrade:
  ```sql
  ALTER EXTENSION pg_session_jwt UPDATE TO '0.5.0';
  ALTER EXTENSION pg_session_jwt UPDATE TO '0.4.0';
  ALTER EXTENSION pg_session_jwt UPDATE TO '0.5.0';
  ```
- [ ] Manual: JWT with valid `"o"` → `auth.organization_id()` returns id; JWT without `"o"` → NULL